### PR TITLE
Resolve package.json path issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "libp2p-floodsub",
   "version": "0.3.0",
   "description": "libp2p-floodsub, also known as pubsub-flood or just dumbsub, this implementation of pubsub focused on delivering an API for Publish/Subscribe, but with no CastTree Forming (it just floods the network).",
-  "main": "lib/core/index.js",
-  "jsnext:main": "src/core/index.js",
+  "main": "lib/index.js",
+  "jsnext:main": "src/index.js",
   "scripts": {
     "lint": "aegir-lint",
     "coverage": "gulp coverage",


### PR DESCRIPTION
cc @diasdavid 

I started working on integrating floodsub into js-ipfs and am still having path issues when using the existing package. I saw [this request closed](https://github.com/libp2p/js-libp2p-floodsub/pull/6) already, but since the issue still stands, now seemed like a good time to re-open the conversation and see if we can get to resolution :)

As such, this request's change is informed by the comment thread from the link above and [the js guidelines](https://github.com/ipfs/community/blob/master/js-project-guidelines.md#default-require). Thanks!