### PR TITLE
Remove fs dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "homepage": "https://github.com/libp2p/js-libp2p-floodsub#readme",
   "devDependencies": {
-    "aegir": "^8.0.1",
+    "aegir": "^9.1.1",
     "chai": "^3.5.0",
     "libp2p-ipfs": "^0.14.1",
     "lodash.times": "^4.3.2",
@@ -51,7 +51,8 @@
     "peer-info": "^0.7.1",
     "pre-commit": "^1.1.3",
     "run-parallel": "^1.1.6",
-    "run-series": "^1.1.4"
+    "run-series": "^1.1.4",
+    "webpack": "2.1.0-beta.25"
   },
   "dependencies": {
     "debug": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -3,20 +3,19 @@
   "version": "0.3.0",
   "description": "libp2p-floodsub, also known as pubsub-flood or just dumbsub, this implementation of pubsub focused on delivering an API for Publish/Subscribe, but with no CastTree Forming (it just floods the network).",
   "main": "src/index.js",
-  "jsnext:main": "src/index.js",
   "scripts": {
     "lint": "aegir-lint",
     "coverage": "gulp coverage",
-    "test": "PHANTOM=off gulp test",
+    "test": "gulp test",
     "test:node": "gulp test:node",
     "test:node:core": "TEST=core npm run test:node",
     "test:node:http": "TEST=http npm run test:node",
     "test:node:cli": "TEST=cli npm run test:node",
-    "test:browser": "PHANTOM=off gulp test:browser",
+    "test:browser": "gulp test:browser",
     "build": "gulp build",
-    "release": "PHANTOM=off gulp release",
-    "release-minor": "PHANTOM=off gulp release --type minor",
-    "release-major": "PHANTOM=off gulp release --type major",
+    "release": "gulp release",
+    "release-minor": "gulp release --type minor",
+    "release-major": "gulp release --type major",
     "coverage-publish": "aegir-coverage publish"
   },
   "pre-commit": [
@@ -42,7 +41,7 @@
   },
   "homepage": "https://github.com/libp2p/js-libp2p-floodsub#readme",
   "devDependencies": {
-    "aegir": "^9.1.1",
+    "aegir": "^9.1.2",
     "chai": "^3.5.0",
     "libp2p-ipfs": "^0.14.1",
     "lodash.times": "^4.3.2",
@@ -51,8 +50,7 @@
     "peer-info": "^0.7.1",
     "pre-commit": "^1.1.3",
     "run-parallel": "^1.1.6",
-    "run-series": "^1.1.4",
-    "webpack": "2.1.0-beta.25"
+    "run-series": "^1.1.4"
   },
   "dependencies": {
     "debug": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "libp2p-floodsub",
   "version": "0.3.0",
   "description": "libp2p-floodsub, also known as pubsub-flood or just dumbsub, this implementation of pubsub focused on delivering an API for Publish/Subscribe, but with no CastTree Forming (it just floods the network).",
-  "main": "lib/index.js",
+  "main": "src/index.js",
   "jsnext:main": "src/index.js",
   "scripts": {
     "lint": "aegir-lint",

--- a/src/message/index.js
+++ b/src/message/index.js
@@ -4,12 +4,9 @@ const fs = require('fs')
 const path = require('path')
 const protobuf = require('protocol-buffers')
 
-const rpcSchema = fs.readFileSync(
-    path.join(__dirname, 'rpc.proto'))
-
-const topicDescriptorSchema = fs.readFileSync(
-    path.join(__dirname, 'topic-descriptor.proto'))
+const rpcProto = protobuf(require('./rpc.proto.js'))
+const topicDescriptorProto = protobuf(require('./topic-descriptor.proto.js'))
 
 exports = module.exports
-exports.rpc = protobuf(rpcSchema)
-exports.td = protobuf(topicDescriptorSchema)
+exports.rpc = rpcProto
+exports.td = topicDescriptorProto

--- a/src/message/index.js
+++ b/src/message/index.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const fs = require('fs')
-const path = require('path')
 const protobuf = require('protocol-buffers')
 
 const rpcProto = protobuf(require('./rpc.proto.js'))

--- a/src/message/rpc.proto.js
+++ b/src/message/rpc.proto.js
@@ -1,5 +1,4 @@
 'use strict'
-
 module.exports = `
 message RPC {
   repeated SubOpts subscriptions = 1;

--- a/src/message/rpc.proto.js
+++ b/src/message/rpc.proto.js
@@ -1,3 +1,6 @@
+'use strict'
+
+module.exports = `
 message RPC {
   repeated SubOpts subscriptions = 1;
   repeated Message msgs = 2;
@@ -13,4 +16,4 @@ message RPC {
     optional bytes seqno = 3;
     repeated string topicCIDs = 4; // CID of topic descriptor object
   }
-}
+}`

--- a/src/message/topic-descriptor.proto.js
+++ b/src/message/topic-descriptor.proto.js
@@ -1,5 +1,4 @@
 'use strict'
-
 module.exports = `
 // topicCID = cid(merkledag_protobuf(topicDescriptor)); (not the topic.name)
 message TopicDescriptor {

--- a/src/message/topic-descriptor.proto.js
+++ b/src/message/topic-descriptor.proto.js
@@ -1,3 +1,6 @@
+'use strict'
+
+module.exports = `
 // topicCID = cid(merkledag_protobuf(topicDescriptor)); (not the topic.name)
 message TopicDescriptor {
   optional string name = 1;
@@ -25,4 +28,5 @@ message TopicDescriptor {
       WOT = 2; // web of trust, certificates can allow publisher set to grow
     }
   }
-}
+}`
+


### PR DESCRIPTION
This PR will remove the dependency on fs module and will fix the browser version.

Previously the .proto files were read with fs.readFileSync() from .proto files. This PR will change it so that the .proto files are now .proto.js files and they get required in message/index.js, which seems to be the way in other js-ipfs modules. This removes the dependency on fs and makes it easier to deal with the browser version.

This PR will also add webpack@2.1.0-beta.25 as a dev dependency because webpack@2.1.0-beta.26 seems to break the build process.

This PR will also update package.json to use latest aegir release.