### PR TITLE
WIP fix: messages don't go out of order

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -257,7 +257,7 @@ class FloodSub extends EventEmitter {
    * @returns {undefined}
    *
    */
-  publish (topics, messages) {
+  publish (topics, messages, callback) {
     assert(this.started, 'FloodSub is not started')
 
     log('publish', topics, messages)
@@ -286,6 +286,8 @@ class FloodSub extends EventEmitter {
 
     // send to all the other peers
     this._forwardMessages(topics, messages.map(buildMessage))
+
+    setImmediate(() => callback)
   }
 
   /**


### PR DESCRIPTION
Still haven't had the time to work properly in this fix, but essentially what needs to happen is that we need a way to signal the sender that the previous message was actually sent.

Currently something is wrong, initially suspicion was that API was not properly sync, but now I wonder if it is a problem with the time-cache that goes wrong with 10K messages in Node.js 4 (very specific)

Tests needs to be added (same test that is in js-ipfs).