### PR TITLE
Fix connection error handling

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -118,7 +118,7 @@ class FloodSub extends EventEmitter {
       pull.map((data) => pb.rpc.RPC.decode(data)),
       pull.drain(
         (rpc) => this._onRpc(idB58Str, rpc),
-        (err) => this._onConnectionEnd(err)
+        (err) => this._onConnectionEnd(idB58Str, err)
       )
     )
   }

--- a/test/multiple-nodes.js
+++ b/test/multiple-nodes.js
@@ -239,7 +239,7 @@ describe('multiple nodes (more than 2)', () => {
         ], (err) => {
           expect(err).to.not.exist
           // wait for the pubsub pipes to be established
-          setTimeout(done, 200)
+          setTimeout(done, 2000)
         })
       })
 


### PR DESCRIPTION
This PR will fix the floodsub's internal connection error handling. 

There was a missing argument on call to _onConnectionEnd() in _processConnection(), which meant that the peer that errored (eg. on connection end) was never removed from the state of floodsub (`.peers`). This in turn caused the bug where upon one peer disconnecting and coming back, the peers were not re-connected nor able to communicate with each other. This bug is fixed with this PR (verified in orbit).

So, if you've seen the behaviour where peers don't reconnect, this was the reason.

cc @VictorBjelkholm I think you experienced this in some of your demos, so fyi.