### PR TITLE
Published message field names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,15 @@
 sudo: false
 language: node_js
-node_js:
-  - 4
-  - 5
-  - stable
-
-# Make sure we have new NPM.
-before_install:
-  - npm install -g npm
+matrix:
+  include:
+  - node_js: 6
+    env: CXX=g++-4.8
+  - node_js: 8
+    env: CXX=g++-4.8
 
 script:
   - npm run lint
-  - npm test
+  - npm run test
   - npm run coverage
 
 
@@ -21,9 +19,6 @@ before_script:
 
 after_success:
   - npm run coverage-publish
-
-env:
-  - CXX=g++-4.8
 
 addons:
   firefox: 'latest'

--- a/src/index.js
+++ b/src/index.js
@@ -157,10 +157,10 @@ class FloodSub extends EventEmitter {
       this.cache.put(seqno)
 
       // 2. emit to self
-      this._emitMessages(msg.topicCIDs, [msg])
+      this._emitMessages(msg.topicIDs, [msg])
 
       // 3. propagate msg to others
-      this._forwardMessages(msg.topicCIDs, [msg])
+      this._forwardMessages(msg.topicIDs, [msg])
     })
   }
 
@@ -277,7 +277,7 @@ class FloodSub extends EventEmitter {
         from: from,
         data: msg,
         seqno: new Buffer(seqno),
-        topicCIDs: topics
+        topicIDs: topics
       }
     }
 

--- a/src/message/rpc.proto.js
+++ b/src/message/rpc.proto.js
@@ -13,6 +13,6 @@ message RPC {
     optional string from = 1;
     optional bytes data = 2;
     optional bytes seqno = 3;
-    repeated string topicCIDs = 4; // CID of topic descriptor object
+    repeated string topicIDs = 4; // CID of topic descriptor object
   }
 }`

--- a/test/2-nodes.js
+++ b/test/2-nodes.js
@@ -131,7 +131,7 @@ describe('basics between 2 nodes', () => {
         expect(msg.data.toString()).to.equal('banana')
         expect(msg.from).to.be.eql(fsB.libp2p.peerInfo.id.toB58String())
         expect(Buffer.isBuffer(msg.seqno)).to.be.true()
-        expect(msg.topicCIDs).to.be.eql(['Z'])
+        expect(msg.topicIDs).to.be.eql(['Z'])
 
         if (++counter === 10) {
           fsA.removeListener('Z', receivedMsg)


### PR DESCRIPTION
JS implementation has renamed the field `topicIDs` to `topicCIDs`, see the [Message spec](https://github.com/libp2p/specs/tree/master/pubsub#the-message). This is not a good idea.  See [background discussion](https://github.com/ipfs/js-ipfs/issues/1068)