### PR TITLE
Various floodsub issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   },
   "dependencies": {
     "async": "^2.6.0",
+    "bs58": "^4.0.1",
     "debug": "^3.1.0",
     "length-prefixed-stream": "^1.5.1",
     "libp2p-crypto": "~0.10.3",

--- a/src/index.js
+++ b/src/index.js
@@ -66,9 +66,8 @@ class FloodSub extends EventEmitter {
     let existing = this.peers.get(id)
     if (existing !== undefined) {
       log('already existing peer', id)
-      ++existing._references;
-    }
-    else {
+      ++existing._references
+    } else {
       log('new peer', id)
       this.peers.set(id, peer)
       existing = peer
@@ -193,7 +192,6 @@ class FloodSub extends EventEmitter {
     if (err && err.message !== 'socket hang up') {
       log.err(err)
     }
-
 
     log('connection ended', idB58Str, err ? err.message : '')
     this._removePeer(peer)

--- a/src/index.js
+++ b/src/index.js
@@ -64,9 +64,9 @@ class FloodSub extends EventEmitter {
 
     /*
       Always use an existing peer.
-      
-      What is happening here is: "If the other peer has already dialed to me, we already have 
-      an establish link between the two, what might be missing is a 
+
+      What is happening here is: "If the other peer has already dialed to me, we already have
+      an establish link between the two, what might be missing is a
       Connection specifically between me and that Peer"
      */
     let existing = this.peers.get(id)

--- a/src/index.js
+++ b/src/index.js
@@ -93,7 +93,6 @@ class FloodSub extends EventEmitter {
     peer.attachConnection(conn)
 
     // Immediately send my own subscriptions to the newly established conn
-    console.log('subs', this.subscriptions)
     peer.sendSubscriptions(this.subscriptions)
     setImmediate(() => callback())
   }
@@ -138,7 +137,7 @@ class FloodSub extends EventEmitter {
     const msgs = rpc.msgs
 
     if (msgs && msgs.length) {
-      this._processRpcMessages(rpc.msgs)
+      this._processRpcMessages(utils.normalizeInRpcMessages(rpc.msgs))
     }
 
     if (subs && subs.length) {
@@ -206,7 +205,7 @@ class FloodSub extends EventEmitter {
         return
       }
 
-      peer.sendMessages(messages)
+      peer.sendMessages(utils.normalizeOutRpcMessages(messages))
 
       log('publish msgs on topics', topics, peer.info.id.toB58String())
     })

--- a/src/index.js
+++ b/src/index.js
@@ -93,6 +93,7 @@ class FloodSub extends EventEmitter {
     peer.attachConnection(conn)
 
     // Immediately send my own subscriptions to the newly established conn
+    console.log('subs', this.subscriptions)
     peer.sendSubscriptions(this.subscriptions)
     setImmediate(() => callback())
   }
@@ -173,11 +174,11 @@ class FloodSub extends EventEmitter {
     }
 
     log('connection ended', idB58Str)
-    const peer = this.peers.get(idB58Str)
-    if (peer && peer.conn === conn) {
+    //const peer = this.peers.get(idB58Str)
+    //if (peer && (peer.conn === null || peer.conn === conn)) {
       log('delete peer', idB58Str)
       this.peers.delete(idB58Str)
-    }
+    //}
   }
 
   _emitMessages (topics, messages) {
@@ -260,6 +261,7 @@ class FloodSub extends EventEmitter {
         return callback(err)
       }
       this.peers = new Map()
+      this.subscriptions = new Set()
       this.started = false
       callback()
     })

--- a/src/index.js
+++ b/src/index.js
@@ -181,10 +181,10 @@ class FloodSub extends EventEmitter {
       this.cache.put(seqno)
 
       // 2. emit to self
-      this._emitMessages(msg.topicCIDs, [msg])
+      this._emitMessages(msg.topicIDs, [msg])
 
       // 3. propagate msg to others
-      this._forwardMessages(msg.topicCIDs, [msg])
+      this._forwardMessages(msg.topicIDs, [msg])
     })
   }
 
@@ -206,14 +206,7 @@ class FloodSub extends EventEmitter {
       }
 
       messages.forEach((message) => {
-        // Convert RPC message to API message
-        const m = {
-          from: message.from,
-          data: message.data,
-          seqno: message.seqno,
-          topicIDs: message.topicCIDs
-        }
-        this.emit(topic, m)
+        this.emit(topic, message)
       })
     })
   }
@@ -314,7 +307,7 @@ class FloodSub extends EventEmitter {
         from: from,
         data: msg,
         seqno: new Buffer(seqno),
-        topicCIDs: topics
+        topicIDs: topics
       }
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -62,9 +62,15 @@ class FloodSub extends EventEmitter {
   _addPeer (peer) {
     const id = peer.info.id.toB58String()
 
-    // Always use an existing peer.
+    /*
+      Always use an existing peer.
+      
+      What is happening here is: "If the other peer has already dialed to me, we already have 
+      an establish link between the two, what might be missing is a 
+      Connection specifically between me and that Peer"
+     */
     let existing = this.peers.get(id)
-    if (existing !== undefined) {
+    if (existing) {
       log('already existing peer', id)
       ++existing._references
     } else {

--- a/src/index.js
+++ b/src/index.js
@@ -218,12 +218,11 @@ class FloodSub extends EventEmitter {
     // Dial already connected peers
     const peerInfos = values(this.libp2p.peerBook.getAll())
 
-    asyncEach(peerInfos, (peer, cb) => this._dialPeer(peer, cb), (err) => {
-      setImmediate(() => {
-        this.started = true
-        callback(err)
-      })
-    })
+    console.log('peerInfos', peerInfos)
+    this.started = true
+    setImmediate(() => callback())
+    
+    asyncEach(peerInfos, (peer, cb) => this._dialPeer(peer, cb), () => { })
   }
 
   /**

--- a/src/index.js
+++ b/src/index.js
@@ -83,7 +83,7 @@ class FloodSub extends EventEmitter {
   _onDial (peerInfo, conn, callback) {
     const idB58Str = peerInfo.id.toB58String()
     log('connected', idB58Str)
-    
+
     // If already had a dial to me, just add the conn
     if (!this.peers.has(idB58Str)) {
       this.peers.set(idB58Str, new Peer(peerInfo))
@@ -178,7 +178,6 @@ class FloodSub extends EventEmitter {
       log('delete peer', idB58Str)
       this.peers.delete(idB58Str)
     }
-    
   }
 
   _emitMessages (topics, messages) {
@@ -239,7 +238,7 @@ class FloodSub extends EventEmitter {
         callback(err)
       })
     })
- }
+  }
 
   /**
    * Unmounts the floodsub protocol and shuts down every connection
@@ -338,7 +337,7 @@ class FloodSub extends EventEmitter {
   unsubscribe (topics) {
     // Avoid race conditions, by quietly ignoring unsub when shutdown.
     if (!this.started) {
-      return;
+      return
     }
 
     topics = ensureArray(topics)

--- a/src/index.js
+++ b/src/index.js
@@ -173,11 +173,11 @@ class FloodSub extends EventEmitter {
     }
 
     log('connection ended', idB58Str)
-    //const peer = this.peers.get(idB58Str)
-    //if (peer && (peer.conn === null || peer.conn === conn)) {
-      log('delete peer', idB58Str)
-      this.peers.delete(idB58Str)
-    //}
+    // const peer = this.peers.get(idB58Str)
+    // if (peer && (peer.conn === null || peer.conn === conn)) {
+    log('delete peer', idB58Str)
+    this.peers.delete(idB58Str)
+    // }
   }
 
   _emitMessages (topics, messages) {

--- a/src/index.js
+++ b/src/index.js
@@ -344,11 +344,11 @@ class FloodSub extends EventEmitter {
         return peer.sendSubscriptions(topics)
       }
       const onConnection = () => {
-        peer.removeListened('connection', onConnection)
+        peer.removeListener('connection', onConnection)
         sendSubscriptionsOnceReady(peer)
       }
       peer.on('connection', onConnection)
-      peer.once('close', () => peer.removeListened('connection', onConnection))
+      peer.once('close', () => peer.removeListener('connection', onConnection))
     }
   }
 

--- a/src/message/rpc.proto.js
+++ b/src/message/rpc.proto.js
@@ -13,6 +13,6 @@ message RPC {
     optional bytes from = 1;
     optional bytes data = 2;
     optional bytes seqno = 3;
-    repeated string topicCIDs = 4; // CID of topic descriptor object
+    repeated string topicIDs = 4; 
   }
 }`

--- a/src/message/rpc.proto.js
+++ b/src/message/rpc.proto.js
@@ -10,7 +10,7 @@ message RPC {
   }
 
   message Message {
-    optional string from = 1;
+    optional bytes from = 1;
     optional bytes data = 2;
     optional bytes seqno = 3;
     repeated string topicCIDs = 4; // CID of topic descriptor object

--- a/src/message/rpc.proto.js
+++ b/src/message/rpc.proto.js
@@ -13,6 +13,6 @@ message RPC {
     optional string from = 1;
     optional bytes data = 2;
     optional bytes seqno = 3;
-    repeated string topicIDs = 4; // CID of topic descriptor object
+    repeated string topicCIDs = 4; // CID of topic descriptor object
   }
 }`

--- a/src/peer.js
+++ b/src/peer.js
@@ -158,7 +158,7 @@ class Peer {
    */
   close (callback) {
     // Force removal of peer
-    this._references = 1;
+    this._references = 1
 
     // End the pushable
     if (this.stream) {

--- a/src/peer.js
+++ b/src/peer.js
@@ -31,6 +31,8 @@ class Peer {
      * @type {Pushable}
      */
     this.stream = null
+
+    this._references = 1
   }
 
   /**
@@ -155,10 +157,14 @@ class Peer {
    * @returns {undefined}
    */
   close (callback) {
-    // end the pushable pull-stream
+    // Force removal of peer
+    this._references = 1;
+
+    // End the pushable
     if (this.stream) {
       this.stream.end()
     }
+
     setImmediate(() => {
       this.conn = null
       this.stream = null

--- a/src/peer.js
+++ b/src/peer.js
@@ -155,9 +155,6 @@ class Peer {
    * @returns {undefined}
    */
   close (callback) {
-    if (!this.conn || !this.stream) {
-      // no connection to close
-    }
     // end the pushable pull-stream
     if (this.stream) {
       this.stream.end()

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const crypto = require('libp2p-crypto')
+const bs58 = require('bs58')
 
 exports = module.exports
 
@@ -65,4 +66,30 @@ exports.ensureArray = (maybeArray) => {
   }
 
   return maybeArray
+}
+
+exports.normalizeInRpcMessages = (messages) => {
+  if (!messages) {
+    return messages;
+  }
+  return messages.map((msg) => {
+    const m = Object.assign({}, msg)
+    if (Buffer.isBuffer(msg.from)) {
+      m.from = bs58.encode(msg.from)
+    }
+    return m;
+  })
+}
+
+exports.normalizeOutRpcMessages = (messages) => {
+  if (!messages) {
+    return messages;
+  }
+  return messages.map((msg) => {
+    const m = Object.assign({}, msg)
+    if (typeof msg.from === 'string' || msg.from instanceof String) {
+      m.from = bs58.decode(msg.from)
+    }
+    return m;
+  })
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -70,26 +70,26 @@ exports.ensureArray = (maybeArray) => {
 
 exports.normalizeInRpcMessages = (messages) => {
   if (!messages) {
-    return messages;
+    return messages
   }
   return messages.map((msg) => {
     const m = Object.assign({}, msg)
     if (Buffer.isBuffer(msg.from)) {
       m.from = bs58.encode(msg.from)
     }
-    return m;
+    return m
   })
 }
 
 exports.normalizeOutRpcMessages = (messages) => {
   if (!messages) {
-    return messages;
+    return messages
   }
   return messages.map((msg) => {
     const m = Object.assign({}, msg)
     if (typeof msg.from === 'string' || msg.from instanceof String) {
       m.from = bs58.decode(msg.from)
     }
-    return m;
+    return m
   })
 }

--- a/test/2-nodes.js
+++ b/test/2-nodes.js
@@ -287,7 +287,7 @@ describe('basics between 2 nodes', () => {
       ], done)
     })
 
-    it('peer is removed from the state when connection ends', (done) => {
+    it.skip('peer is removed from the state when connection ends', (done) => {
       nodeA.dial(nodeB.peerInfo, (err) => {
         expect(err).to.not.exist()
         setTimeout(() => {

--- a/test/2-nodes.js
+++ b/test/2-nodes.js
@@ -142,6 +142,30 @@ describe('basics between 2 nodes', () => {
       _times(10, () => fsB.publish('Z', new Buffer('banana')))
     })
 
+    it('Publish 10 msg to a topic:Z in nodeB as array', (done) => {
+      let counter = 0
+
+      fsB.once('Z', shouldNotHappen)
+
+      fsA.on('Z', receivedMsg)
+
+      function receivedMsg (msg) {
+        expect(msg.data.toString()).to.equal('banana')
+        expect(msg.from).to.be.eql(fsB.libp2p.peerInfo.id.toB58String())
+        expect(Buffer.isBuffer(msg.seqno)).to.be.true()
+        expect(msg.topicIDs).to.be.eql(['Z'])
+
+        if (++counter === 10) {
+          fsA.removeListener('Z', receivedMsg)
+          done()
+        }
+      }
+
+      let msgs = []
+      _times(10, () => msgs.push(new Buffer('banana')))
+      fsB.publish('Z', msgs)
+    })
+
     it('Unsubscribe from topic:Z in nodeA', (done) => {
       fsA.unsubscribe('Z')
       expect(fsA.subscriptions.size).to.equal(0)

--- a/test/2-nodes.js
+++ b/test/2-nodes.js
@@ -287,15 +287,15 @@ describe('basics between 2 nodes', () => {
       ], done)
     })
 
-    it.skip('peer is removed from the state when connection ends', (done) => {
+    it('peer is removed from the state when connection ends', (done) => {
       nodeA.dial(nodeB.peerInfo, (err) => {
         expect(err).to.not.exist()
         setTimeout(() => {
-          expect(fsA.peers.size).to.equal(1)
-          expect(fsB.peers.size).to.equal(1)
+          expect(first(fsA.peers)._references).to.equal(2)
+          expect(first(fsB.peers)._references).to.equal(2)
 
           fsA.stop(() => setTimeout(() => {
-            expect(fsB.peers.size).to.equal(0)
+            expect(first(fsB.peers)._references).to.equal(1)
             done()
           }, 250))
         }, 1000)

--- a/test/multiple-nodes.js
+++ b/test/multiple-nodes.js
@@ -135,6 +135,30 @@ describe('multiple nodes (more than 2)', () => {
         }
       })
 
+      it('publish array on node a', (done) => {
+        let counter = 0
+
+        a.ps.on('Z', incMsg)
+        b.ps.on('Z', incMsg)
+        c.ps.on('Z', incMsg)
+
+        a.ps.publish('Z', [Buffer.from('hey'), Buffer.from('hey')])
+
+        function incMsg (msg) {
+          expect(msg.data.toString()).to.equal('hey')
+          check()
+        }
+
+        function check () {
+          if (++counter === 6) {
+            a.ps.removeListener('Z', incMsg)
+            b.ps.removeListener('Z', incMsg)
+            c.ps.removeListener('Z', incMsg)
+            done()
+          }
+        }
+      })
+
       // since the topology is the same, just the publish
       // gets sent by other peer, we reused the same peers
       describe('1 level tree', () => {

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -40,4 +40,32 @@ describe('utils', () => {
     expect(utils.ensureArray('hello')).to.be.eql(['hello'])
     expect(utils.ensureArray([1, 2])).to.be.eql([1, 2])
   })
+
+  it('converts an IN msg.from to b58', () => {
+    let binaryId = Buffer.from('1220e2187eb3e6c4fb3e7ff9ad4658610624a6315e0240fc6f37130eedb661e939cc', 'hex')
+    let stringId = 'QmdZEWgtaWAxBh93fELFT298La1rsZfhiC2pqwMVwy3jZM'
+    const m = [
+      { from: binaryId },
+      { from: stringId }
+    ]
+    const expected = [
+      { from: stringId },
+      { from: stringId }
+    ];
+    expect(utils.normalizeInRpcMessages(m)).to.deep.eql(expected)
+  })
+
+  it('converts an OUT msg.from to binary', () => {
+    let binaryId = Buffer.from('1220e2187eb3e6c4fb3e7ff9ad4658610624a6315e0240fc6f37130eedb661e939cc', 'hex')
+    let stringId = 'QmdZEWgtaWAxBh93fELFT298La1rsZfhiC2pqwMVwy3jZM'
+    const m = [
+      { from: binaryId },
+      { from: stringId }
+    ]
+    const expected = [
+      { from: binaryId },
+      { from: binaryId }
+    ];
+    expect(utils.normalizeOutRpcMessages(m)).to.deep.eql(expected)
+  })
 })

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -51,7 +51,7 @@ describe('utils', () => {
     const expected = [
       { from: stringId },
       { from: stringId }
-    ];
+    ]
     expect(utils.normalizeInRpcMessages(m)).to.deep.eql(expected)
   })
 
@@ -65,7 +65,7 @@ describe('utils', () => {
     const expected = [
       { from: binaryId },
       { from: binaryId }
-    ];
+    ]
     expect(utils.normalizeOutRpcMessages(m)).to.deep.eql(expected)
   })
 })


### PR DESCRIPTION
Some of the issues were introduced by me in https://github.com/libp2p/js-libp2p-floodsub/pull/49.  Basically, the field `topicCIDs` is used in RPC messages and `topicIDs` in API messages.

See issue #50

Summary of changes
- multiple peer connections
- RPC message changed to have binary `from`
- Avoid race conditions, by quietly ignoring unsub when shutdown
