### PR TITLE
feat: add support for signing

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "debug": "^4.1.1",
     "length-prefixed-stream": "^2.0.0",
     "libp2p-crypto": "~0.16.1",
-    "libp2p-pubsub": "~0.0.4",
+    "libp2p-pubsub": "libp2p/js-libp2p-pubsub#feat/signing",
     "protons": "^1.0.1",
     "pull-length-prefixed": "^1.3.2",
     "pull-pushable": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "debug": "^4.1.1",
     "length-prefixed-stream": "^2.0.0",
     "libp2p-crypto": "~0.16.1",
-    "libp2p-pubsub": "libp2p/js-libp2p-pubsub#feat/signing",
+    "libp2p-pubsub": "~0.1.0",
     "protons": "^1.0.1",
     "pull-length-prefixed": "^1.3.2",
     "pull-pushable": "^2.2.0",

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ const multicodec = config.multicodec
 const ensureArray = utils.ensureArray
 const setImmediate = require('async/setImmediate')
 const asyncMap = require('async/map')
+const noop = () => {}
 
 /**
  * FloodSub (aka dumbsub is an implementation of pubsub focused on
@@ -165,6 +166,7 @@ class FloodSub extends BaseProtocol {
    */
   publish (topics, messages, callback) {
     assert(this.started, 'FloodSub is not started')
+    callback = callback || noop
 
     this.log('publish', topics, messages)
 


### PR DESCRIPTION
The new publish callback will default to a noop function.

All published messages will be signed.

Requires https://github.com/libp2p/js-libp2p-pubsub/pull/17

Ref: https://github.com/libp2p/js-libp2p-pubsub/issues/16