### PR TITLE
chore: export multicodec

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -259,3 +259,4 @@ class FloodSub extends BaseProtocol {
 }
 
 module.exports = FloodSub
+module.exports.multicodec = multicodec

--- a/test/pubsub.spec.js
+++ b/test/pubsub.spec.js
@@ -16,6 +16,8 @@ describe('pubsub', () => {
   let libp2p
 
   before((done) => {
+    expect(Floodsub.multicodec).to.exist()
+
     createNode((err, node) => {
       expect(err).to.not.exist()
       libp2p = node


### PR DESCRIPTION
Added export for multicodec, so that Gossipsub can use it, when tries to fallback a dial to floodsub