### PR TITLE
feat: pass options to base protocol constructor

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,7 @@ class FloodSub extends BaseProtocol {
    * @constructor
    */
   constructor (libp2p, options = {}) {
-    super('libp2p:floodsub', multicodec, libp2p)
+    super('libp2p:floodsub', multicodec, libp2p, options)
 
     /**
      * List of our subscriptions


### PR DESCRIPTION
Pass options to `PubsubBaseProtocol` constructor, so can configure the following options:

**signMessages** if messages should be signed, defaults to true

**strictSigning** if message signing should be required, defaults to true
