### PR TITLE
chore: emit self default to false

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ const floodsub = new Floodsub(libp2pNode, options)
 
 Options is an optional object with the following key-value pairs:
 
-* **`emitSelf`**: boolean identifying whether the node should emit to self on publish, in the event of the topic being subscribed (defaults to **true**).
+* **`emitSelf`**: boolean identifying whether the node should emit to self on publish, in the event of the topic being subscribed (defaults to **false**).
 
 For more, see https://libp2p.github.io/js-libp2p-floodsub
 

--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,7 @@ class FloodSub extends BaseProtocol {
   /**
    * @param {Object} libp2p an instance of Libp2p
    * @param {Object} [options]
-   * @param {boolean} options.emitSelf if publish should emit to self, if subscribed, defaults to true
+   * @param {boolean} options.emitSelf if publish should emit to self, if subscribed, defaults to false
    * @constructor
    */
   constructor (libp2p, options = {}) {
@@ -39,7 +39,7 @@ class FloodSub extends BaseProtocol {
      * Pubsub options
      */
     this._options = {
-      emitSelf: true,
+      emitSelf: false,
       ...options
     }
   }

--- a/test/2-nodes.spec.js
+++ b/test/2-nodes.spec.js
@@ -45,8 +45,8 @@ describe('basics between 2 nodes', () => {
     })
 
     it('Mount the pubsub protocol', (done) => {
-      fsA = new FloodSub(nodeA)
-      fsB = new FloodSub(nodeB)
+      fsA = new FloodSub(nodeA, { emitSelf: true })
+      fsB = new FloodSub(nodeB, { emitSelf: true })
 
       setTimeout(() => {
         expect(fsA.peers.size).to.be.eql(0)
@@ -369,8 +369,8 @@ describe('basics between 2 nodes', () => {
     })
 
     it('dial on floodsub on mount', (done) => {
-      fsA = new FloodSub(nodeA)
-      fsB = new FloodSub(nodeB)
+      fsA = new FloodSub(nodeA, { emitSelf: true })
+      fsB = new FloodSub(nodeB, { emitSelf: true })
 
       parallel([
         (cb) => fsA.start(cb),

--- a/test/multiple-nodes.spec.js
+++ b/test/multiple-nodes.spec.js
@@ -352,7 +352,7 @@ function spawnPubSubNode (callback) {
     if (err) {
       return callback(err)
     }
-    const ps = new FloodSub(node)
+    const ps = new FloodSub(node, { emitSelf: true })
     ps.start((err) => {
       if (err) {
         return callback(err)

--- a/test/pubsub.spec.js
+++ b/test/pubsub.spec.js
@@ -22,7 +22,7 @@ describe('pubsub', () => {
     createNode((err, node) => {
       expect(err).to.not.exist()
       libp2p = node
-      floodsub = new Floodsub(libp2p)
+      floodsub = new Floodsub(libp2p, { emitSelf: true })
       done(err)
     })
   })


### PR DESCRIPTION
BREAKING CHANGE: messages are not self emitted by default anymore. You need to set the emitSelf option to true to use it

On the context of [libp2p/js-libp2p-pubsub#22](https://github.com/libp2p/js-libp2p-pubsub/issues/22), `emitSelf` option defaults to false