### PR TITLE
chore: remove peer-info usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ js-libp2p-floodsub
 const FloodSub = require('libp2p-floodsub')
 
 // registrar is provided by libp2p
-const fsub = new FloodSub(peerInfo, registrar, options)
+const fsub = new FloodSub(peerId, registrar, options)
 
 await fsub.start()
 
@@ -56,7 +56,7 @@ fsub.publish('fruit', new Buffer('banana'))
 
 ```js
 const options = {…}
-const floodsub = new Floodsub(peerInfo, registrar, options)
+const floodsub = new Floodsub(peerId, registrar, options)
 ```
 
 Options is an optional object with the following key-value pairs:
@@ -75,9 +75,9 @@ Floodsub emits two kinds of events:
   - `data`: a Buffer containing the data that was published to the topic
 2. `floodsub:subscription-change` when the local peer receives an update to the subscriptions of a remote peer.
   ```Javascript
-    fsub.on('floodsub:subscription-change', (peerInfo, topics, changes) => { ... })
+    fsub.on('floodsub:subscription-change', (peerId, topics, changes) => { ... })
   ```
-  - `peerInfo`: a [PeerInfo](https://github.com/libp2p/js-peer-info) object
+  - `peerId`: a [PeerId](https://github.com/libp2p/js-peer-id) object
   - `topics`: the topics that the peer is now subscribed to
   - `changes`: an array of `{ topicID: <topic>, subscribe: <boolean> }`
      eg `[ { topicID: 'fruit', subscribe: true }, { topicID: 'vegetables': false } ]`

--- a/package.json
+++ b/package.json
@@ -52,8 +52,6 @@
     "lodash": "^4.17.15",
     "multiaddr": "^7.1.0",
     "p-defer": "^3.0.0",
-    "peer-id": "~0.13.3",
-    "peer-info": "~0.17.0",
     "sinon": "^9.0.1"
   },
   "dependencies": {
@@ -61,8 +59,9 @@
     "debug": "^4.1.1",
     "it-length-prefixed": "^3.0.0",
     "it-pipe": "^1.0.1",
-    "libp2p-pubsub": "~0.4.0",
+    "libp2p-pubsub": "^0.5.0",
     "p-map": "^3.0.0",
+    "peer-id": "~0.13.3",
     "protons": "^1.0.1",
     "time-cache": "^0.3.0"
   },

--- a/test/emit-self.spec.js
+++ b/test/emit-self.spec.js
@@ -9,20 +9,20 @@ const expect = chai.expect
 const FloodSub = require('../src')
 
 const {
-  createPeerInfo, mockRegistrar
+  createPeerId, mockRegistrar
 } = require('./utils')
 
 const shouldNotHappen = (_) => expect.fail()
 
 describe('emit self', () => {
   let floodsub
-  let peerInfo
+  let peerId
   const topic = 'Z'
 
   describe('enabled', () => {
     before(async () => {
-      peerInfo = await createPeerInfo()
-      floodsub = new FloodSub(peerInfo, mockRegistrar, { emitSelf: true })
+      peerId = await createPeerId()
+      floodsub = new FloodSub(peerId, mockRegistrar, { emitSelf: true })
     })
 
     before(async () => {
@@ -44,8 +44,8 @@ describe('emit self', () => {
 
   describe('disabled', () => {
     before(async () => {
-      peerInfo = await createPeerInfo()
-      floodsub = new FloodSub(peerInfo, mockRegistrar, { emitSelf: false })
+      peerId = await createPeerId()
+      floodsub = new FloodSub(peerId, mockRegistrar, { emitSelf: false })
     })
 
     before(async () => {

--- a/test/multiple-nodes.spec.js
+++ b/test/multiple-nodes.spec.js
@@ -11,15 +11,15 @@ const pDefer = require('p-defer')
 const FloodSub = require('../src')
 const { multicodec } = require('../src')
 const {
-  createPeerInfo,
+  createPeerId,
   createMockRegistrar,
   first,
   expectSet,
   ConnectionPair
 } = require('./utils')
 
-async function spawnPubSubNode (peerInfo, reg) {
-  const ps = new FloodSub(peerInfo, reg, { emitSelf: true })
+async function spawnPubSubNode (peerId, reg) {
+  const ps = new FloodSub(peerId, reg, { emitSelf: true })
 
   await ps.start()
   return ps
@@ -32,23 +32,23 @@ describe('multiple nodes (more than 2)', () => {
       // ◉────◉────◉
       // a    b    c
       let psA, psB, psC
-      let peerInfoA, peerInfoB, peerInfoC
+      let peerIdA, peerIdB, peerIdC
 
       const registrarRecordA = {}
       const registrarRecordB = {}
       const registrarRecordC = {}
 
       before(async () => {
-        [peerInfoA, peerInfoB, peerInfoC] = await Promise.all([
-          createPeerInfo(),
-          createPeerInfo(),
-          createPeerInfo()
+        [peerIdA, peerIdB, peerIdC] = await Promise.all([
+          createPeerId(),
+          createPeerId(),
+          createPeerId()
         ]);
 
         [psA, psB, psC] = await Promise.all([
-          spawnPubSubNode(peerInfoA, createMockRegistrar(registrarRecordA)),
-          spawnPubSubNode(peerInfoB, createMockRegistrar(registrarRecordB)),
-          spawnPubSubNode(peerInfoC, createMockRegistrar(registrarRecordC))
+          spawnPubSubNode(peerIdA, createMockRegistrar(registrarRecordA)),
+          spawnPubSubNode(peerIdB, createMockRegistrar(registrarRecordB)),
+          spawnPubSubNode(peerIdC, createMockRegistrar(registrarRecordC))
         ])
       })
 
@@ -60,12 +60,12 @@ describe('multiple nodes (more than 2)', () => {
 
         // Notice peers of connection
         const [d0, d1] = ConnectionPair()
-        await onConnectA(peerInfoB, d0)
-        await onConnectB(peerInfoA, d1)
+        await onConnectA(peerIdB, d0)
+        await onConnectB(peerIdA, d1)
 
         const [d2, d3] = ConnectionPair()
-        await onConnectB(peerInfoC, d2)
-        await onConnectC(peerInfoB, d3)
+        await onConnectB(peerIdC, d2)
+        await onConnectC(peerIdB, d3)
       })
 
       after(() => Promise.all([
@@ -82,7 +82,7 @@ describe('multiple nodes (more than 2)', () => {
 
         psB.once('floodsub:subscription-change', () => {
           expect(psB.peers.size).to.equal(2)
-          const aPeerId = psA.peerInfo.id.toB58String()
+          const aPeerId = psA.peerId.toB58String()
           const topics = psB.peers.get(aPeerId).topics
           expectSet(topics, ['Z'])
 
@@ -234,7 +234,7 @@ describe('multiple nodes (more than 2)', () => {
       // ◉─┘       └─◉
       // a
       let psA, psB, psC, psD, psE
-      let peerInfoA, peerInfoB, peerInfoC, peerInfoD, peerInfoE
+      let peerIdA, peerIdB, peerIdC, peerIdD, peerIdE
 
       const registrarRecordA = {}
       const registrarRecordB = {}
@@ -243,20 +243,20 @@ describe('multiple nodes (more than 2)', () => {
       const registrarRecordE = {}
 
       before(async () => {
-        [peerInfoA, peerInfoB, peerInfoC, peerInfoD, peerInfoE] = await Promise.all([
-          createPeerInfo(),
-          createPeerInfo(),
-          createPeerInfo(),
-          createPeerInfo(),
-          createPeerInfo()
+        [peerIdA, peerIdB, peerIdC, peerIdD, peerIdE] = await Promise.all([
+          createPeerId(),
+          createPeerId(),
+          createPeerId(),
+          createPeerId(),
+          createPeerId()
         ]);
 
         [psA, psB, psC, psD, psE] = await Promise.all([
-          spawnPubSubNode(peerInfoA, createMockRegistrar(registrarRecordA)),
-          spawnPubSubNode(peerInfoB, createMockRegistrar(registrarRecordB)),
-          spawnPubSubNode(peerInfoC, createMockRegistrar(registrarRecordC)),
-          spawnPubSubNode(peerInfoD, createMockRegistrar(registrarRecordD)),
-          spawnPubSubNode(peerInfoE, createMockRegistrar(registrarRecordE))
+          spawnPubSubNode(peerIdA, createMockRegistrar(registrarRecordA)),
+          spawnPubSubNode(peerIdB, createMockRegistrar(registrarRecordB)),
+          spawnPubSubNode(peerIdC, createMockRegistrar(registrarRecordC)),
+          spawnPubSubNode(peerIdD, createMockRegistrar(registrarRecordD)),
+          spawnPubSubNode(peerIdE, createMockRegistrar(registrarRecordE))
         ])
       })
 
@@ -270,20 +270,20 @@ describe('multiple nodes (more than 2)', () => {
 
         // Notice peers of connection
         const [d0, d1] = ConnectionPair() // A <-> B
-        await onConnectA(peerInfoB, d0)
-        await onConnectB(peerInfoA, d1)
+        await onConnectA(peerIdB, d0)
+        await onConnectB(peerIdA, d1)
 
         const [d2, d3] = ConnectionPair() // B <-> C
-        await onConnectB(peerInfoC, d2)
-        await onConnectC(peerInfoB, d3)
+        await onConnectB(peerIdC, d2)
+        await onConnectC(peerIdB, d3)
 
         const [d4, d5] = ConnectionPair() // C <-> D
-        await onConnectC(peerInfoD, d4)
-        await onConnectD(peerInfoC, d5)
+        await onConnectC(peerIdD, d4)
+        await onConnectD(peerIdC, d5)
 
         const [d6, d7] = ConnectionPair() // C <-> D
-        await onConnectD(peerInfoE, d6)
-        await onConnectE(peerInfoD, d7)
+        await onConnectD(peerIdE, d6)
+        await onConnectE(peerIdD, d7)
       })
 
       after(() => Promise.all([

--- a/test/pubsub.spec.js
+++ b/test/pubsub.spec.js
@@ -8,7 +8,7 @@ const expect = chai.expect
 const sinon = require('sinon')
 
 const Floodsub = require('../src')
-const { createPeerInfo, mockRegistrar } = require('./utils')
+const { createPeerId, mockRegistrar } = require('./utils')
 const { utils } = require('libp2p-pubsub')
 
 const defOptions = {
@@ -17,13 +17,13 @@ const defOptions = {
 
 describe('pubsub', () => {
   let floodsub
-  let peerInfo
+  let peerId
 
   before(async () => {
     expect(Floodsub.multicodec).to.exist()
 
-    peerInfo = await createPeerInfo()
-    floodsub = new Floodsub(peerInfo, mockRegistrar, defOptions)
+    peerId = await createPeerId()
+    floodsub = new Floodsub(peerId, mockRegistrar, defOptions)
   })
 
   beforeEach(() => {
@@ -49,7 +49,7 @@ describe('pubsub', () => {
       const [topics, messages] = floodsub._emitMessages.getCall(0).args
       expect(topics).to.eql([topic])
       expect(messages).to.eql([{
-        from: peerInfo.id.toB58String(),
+        from: peerId.toB58String(),
         data: message,
         seqno: utils.randomSeqno.getCall(0).returnValue,
         topicIDs: topics
@@ -68,7 +68,7 @@ describe('pubsub', () => {
       const [topics, messages] = floodsub._forwardMessages.getCall(0).args
 
       const expected = await floodsub._buildMessage({
-        from: peerInfo.id.toB58String(),
+        from: peerId.toB58String(),
         data: message,
         seqno: utils.randomSeqno.getCall(0).returnValue,
         topicIDs: topics
@@ -91,7 +91,7 @@ describe('pubsub', () => {
       const rpc = {
         subscriptions: [],
         msgs: [{
-          from: peerInfo.id.id,
+          from: peerId.id,
           data: Buffer.from('an unsigned message'),
           seqno: utils.randomSeqno(),
           topicIDs: [topic]
@@ -121,7 +121,7 @@ describe('pubsub', () => {
       const rpc = {
         subscriptions: [],
         msgs: [{
-          from: peerInfo.id.id,
+          from: peerId.id,
           data: Buffer.from('an unsigned message'),
           seqno: utils.randomSeqno(),
           topicIDs: [topic]

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const PeerId = require('peer-id')
-const PeerInfo = require('peer-info')
 const DuplexPair = require('it-pair/duplex')
 
 const { expect } = require('chai')
@@ -12,10 +11,10 @@ exports.expectSet = (set, subs) => {
   expect(Array.from(set.values())).to.eql(subs)
 }
 
-exports.createPeerInfo = async () => {
+exports.createPeerId = async () => {
   const peerId = await PeerId.create({ bits: 1024 })
 
-  return PeerInfo.create(peerId)
+  return peerId
 }
 
 exports.mockRegistrar = {


### PR DESCRIPTION
In the context of deprecating `peer-info` as described on [libp2p/js-libp2p#589](https://github.com/libp2p/js-libp2p/issues/589), this PR removes the `peer-info` usage on pubsub internal peer data structure. Moreover, this uses the new topology API, which also uses `peer-id` instead of `peer-info`

BREAKING CHANGE: using new topology api with peer-id instead of peer-info and new pubsub internal peer data structure

Needs:

- [x] [libp2p/js-libp2p-interfaces#42](https://github.com/libp2p/js-libp2p-interfaces/pull/42)
- [x] [libp2p/js-libp2p-pubsub#41](https://github.com/libp2p/js-libp2p-pubsub/pull/41)