### PR TITLE
fix: use unidirectional streams v0.20.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "debug": "^4.1.1",
     "it-length-prefixed": "^3.0.0",
     "it-pipe": "^1.0.1",
-    "libp2p-pubsub": "libp2p/js-libp2p-pubsub#fix/use-unidirectional-streams-v0.4.x",
+    "libp2p-pubsub": "~0.4.5",
     "p-map": "^3.0.0",
     "protons": "^1.0.1",
     "time-cache": "^0.3.0"

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "debug": "^4.1.1",
     "it-length-prefixed": "^3.0.0",
     "it-pipe": "^1.0.1",
-    "libp2p-pubsub": "~0.4.0",
+    "libp2p-pubsub": "libp2p/js-libp2p-pubsub#fix/use-unidirectional-streams-v0.4.x",
     "p-map": "^3.0.0",
     "protons": "^1.0.1",
     "time-cache": "^0.3.0"

--- a/test/2-nodes.spec.js
+++ b/test/2-nodes.spec.js
@@ -58,17 +58,28 @@ describe('basics between 2 nodes', () => {
     // Connect floodsub nodes
     before(async () => {
       const onConnectA = registrarRecordA[multicodec].onConnect
+      const onConnectB = registrarRecordB[multicodec].onConnect
+      const handleA = registrarRecordA[multicodec].handler
       const handleB = registrarRecordB[multicodec].handler
 
       // Notice peers of connection
       const [c0, c1] = ConnectionPair()
       await onConnectA(peerInfoB, c0)
+      await onConnectB(peerInfoA, c1)
 
       await handleB({
         protocol: multicodec,
         stream: c1.stream,
         connection: {
           remotePeer: peerInfoA.id
+        }
+      })
+
+      await handleA({
+        protocol: multicodec,
+        stream: c0.stream,
+        connection: {
+          remotePeer: peerInfoB.id
         }
       })
 
@@ -275,11 +286,27 @@ describe('basics between 2 nodes', () => {
       const dial = async () => {
         const onConnectA = registrarRecordA[multicodec].onConnect
         const onConnectB = registrarRecordB[multicodec].onConnect
+        const handleA = registrarRecordA[multicodec].handler
+        const handleB = registrarRecordB[multicodec].handler
 
         // Notice peers of connection
         const [c0, c1] = ConnectionPair()
         await onConnectA(peerInfoB, c0)
+        await handleB({
+          protocol: multicodec,
+          stream: c1.stream,
+          connection: {
+            remotePeer: peerInfoA.id
+          }
+        })
         await onConnectB(peerInfoA, c1)
+        await handleA({
+          protocol: multicodec,
+          stream: c0.stream,
+          connection: {
+            remotePeer: peerInfoB.id
+          }
+        })
       }
 
       await Promise.all([

--- a/test/multiple-nodes.spec.js
+++ b/test/multiple-nodes.spec.js
@@ -57,15 +57,46 @@ describe('multiple nodes (more than 2)', () => {
         const onConnectA = registrarRecordA[multicodec].onConnect
         const onConnectB = registrarRecordB[multicodec].onConnect
         const onConnectC = registrarRecordC[multicodec].onConnect
+        const handleA = registrarRecordA[multicodec].handler
+        const handleB = registrarRecordB[multicodec].handler
+        const handleC = registrarRecordC[multicodec].handler
 
         // Notice peers of connection
         const [d0, d1] = ConnectionPair()
         await onConnectA(peerInfoB, d0)
+        await handleB({
+          protocol: multicodec,
+          stream: d1.stream,
+          connection: {
+            remotePeer: peerInfoA.id
+          }
+        })
         await onConnectB(peerInfoA, d1)
+        await handleA({
+          protocol: multicodec,
+          stream: d0.stream,
+          connection: {
+            remotePeer: peerInfoB.id
+          }
+        })
 
         const [d2, d3] = ConnectionPair()
         await onConnectB(peerInfoC, d2)
+        await handleC({
+          protocol: multicodec,
+          stream: d3.stream,
+          connection: {
+            remotePeer: peerInfoB.id
+          }
+        })
         await onConnectC(peerInfoB, d3)
+        await handleB({
+          protocol: multicodec,
+          stream: d2.stream,
+          connection: {
+            remotePeer: peerInfoC.id
+          }
+        })
       })
 
       after(() => Promise.all([
@@ -267,23 +298,85 @@ describe('multiple nodes (more than 2)', () => {
         const onConnectC = registrarRecordC[multicodec].onConnect
         const onConnectD = registrarRecordD[multicodec].onConnect
         const onConnectE = registrarRecordE[multicodec].onConnect
+        const handleA = registrarRecordA[multicodec].handler
+        const handleB = registrarRecordB[multicodec].handler
+        const handleC = registrarRecordC[multicodec].handler
+        const handleD = registrarRecordD[multicodec].handler
+        const handleE = registrarRecordE[multicodec].handler
 
         // Notice peers of connection
         const [d0, d1] = ConnectionPair() // A <-> B
         await onConnectA(peerInfoB, d0)
+        await handleB({
+          protocol: multicodec,
+          stream: d1.stream,
+          connection: {
+            remotePeer: peerInfoA.id
+          }
+        })
         await onConnectB(peerInfoA, d1)
+        await handleA({
+          protocol: multicodec,
+          stream: d0.stream,
+          connection: {
+            remotePeer: peerInfoB.id
+          }
+        })
 
         const [d2, d3] = ConnectionPair() // B <-> C
         await onConnectB(peerInfoC, d2)
+        await handleC({
+          protocol: multicodec,
+          stream: d3.stream,
+          connection: {
+            remotePeer: peerInfoB.id
+          }
+        })
         await onConnectC(peerInfoB, d3)
+        await handleB({
+          protocol: multicodec,
+          stream: d2.stream,
+          connection: {
+            remotePeer: peerInfoC.id
+          }
+        })
 
         const [d4, d5] = ConnectionPair() // C <-> D
         await onConnectC(peerInfoD, d4)
+        await handleD({
+          protocol: multicodec,
+          stream: d5.stream,
+          connection: {
+            remotePeer: peerInfoC.id
+          }
+        })
         await onConnectD(peerInfoC, d5)
+        await handleC({
+          protocol: multicodec,
+          stream: d4.stream,
+          connection: {
+            remotePeer: peerInfoD.id
+          }
+        })
 
-        const [d6, d7] = ConnectionPair() // C <-> D
+        const [d6, d7] = ConnectionPair() // D <-> E
         await onConnectD(peerInfoE, d6)
+        await handleE({
+          protocol: multicodec,
+          stream: d7.stream,
+          connection: {
+            remotePeer: peerInfoD.id
+          }
+        })
+
         await onConnectE(peerInfoD, d7)
+        await handleD({
+          protocol: multicodec,
+          stream: d6.stream,
+          connection: {
+            remotePeer: peerInfoE.id
+          }
+        })
       })
 
       after(() => Promise.all([


### PR DESCRIPTION
This PR makes libp2p pubsub subsystem use unidirectional streams instead of bidirectional streams per discussion on [ipfs/go-ipfs#7390](https://github.com/ipfs/go-ipfs/issues/7390).

More details about the reasoning for this can be found in https://discuss.libp2p.io/t/gossip-questions/257/6

This PR replicates #105 for the `0.20.x` version range of `libp2p-floodsub`

Bear in mind that a lot of this "connection logic" can be abstracted. I did not worry about it and just followed what we already had in floodsub and gossipsub. Hopefully, after `gossipsub@1.1`, I want to create the libp2p pubsub interface and move/refactor the tests there and re-use most of them in all our router implementations.

Needs:

- [x] https://github.com/libp2p/js-libp2p-pubsub/pull/46