### PR TITLE
fix: replace node buffers with uint8arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,16 @@ js-libp2p-floodsub
 
 ## Table of Contents
 
-- [Install](#install)
-- [Usage](#usage)
-- [API](#api)
-- [Events](#events)
-- [Contribute](#contribute)
-- [License](#license)
+- [js-libp2p-floodsub](#js-libp2p-floodsub)
+  - [Lead Maintainer](#lead-maintainer)
+  - [Table of Contents](#table-of-contents)
+  - [Install](#install)
+  - [Usage](#usage)
+  - [API](#api)
+    - [Create a floodsub implementation](#create-a-floodsub-implementation)
+  - [Events](#events)
+  - [Contribute](#contribute)
+  - [License](#license)
 
 ## Install
 
@@ -47,7 +51,7 @@ fsub.on('fruit', (data) => {
 })
 fsub.subscribe('fruit')
 
-fsub.publish('fruit', new Buffer('banana'))
+fsub.publish('fruit', new TextEncoder().encode('banana'))
 ```
 
 ## API
@@ -72,7 +76,7 @@ Floodsub emits two kinds of events:
   ```Javascript
     fsub.on('fruit', (data) => { ... })
   ```
-  - `data`: a Buffer containing the data that was published to the topic
+  - `data`: a Uint8Array containing the data that was published to the topic
 2. `floodsub:subscription-change` when the local peer receives an update to the subscriptions of a remote peer.
   ```Javascript
     fsub.on('floodsub:subscription-change', (peerId, topics, changes) => { ... })

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "debug": "^4.1.1",
     "it-length-prefixed": "^3.0.0",
     "it-pipe": "^1.0.1",
-    "libp2p-pubsub": "~0.5.2",
+    "libp2p-pubsub": "~0.6.0",
     "p-map": "^4.0.0",
     "peer-id": "~0.14.0",
     "protons": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "homepage": "https://github.com/libp2p/js-libp2p-floodsub#readme",
   "devDependencies": {
-    "aegir": "^22.0.0",
+    "aegir": "^25.0.0",
     "benchmark": "^2.1.4",
     "chai": "^4.2.0",
     "chai-spies": "^1.0.0",
@@ -50,21 +50,21 @@
     "dirty-chai": "^2.0.1",
     "it-pair": "^1.0.0",
     "lodash": "^4.17.15",
-    "multiaddr": "^7.1.0",
+    "multiaddr": "^8.0.0",
     "p-defer": "^3.0.0",
     "sinon": "^9.0.1"
   },
   "dependencies": {
     "async.nexttick": "^0.5.2",
-    "buffer": "^5.6.0",
     "debug": "^4.1.1",
     "it-length-prefixed": "^3.0.0",
     "it-pipe": "^1.0.1",
     "libp2p-pubsub": "~0.5.2",
     "p-map": "^4.0.0",
-    "peer-id": "~0.13.3",
-    "protons": "^1.0.1",
-    "time-cache": "^0.3.0"
+    "peer-id": "~0.14.0",
+    "protons": "^2.0.0",
+    "time-cache": "^0.3.0",
+    "uint8arrays": "^1.1.0"
   },
   "contributors": [
     "David Dias <daviddias.p@gmail.com>",

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,6 @@ const lp = require('it-length-prefixed')
 const pMap = require('p-map')
 const TimeCache = require('time-cache')
 const nextTick = require('async.nexttick')
-const { Buffer } = require('buffer')
 const PeerId = require('peer-id')
 const BaseProtocol = require('libp2p-pubsub')
 const { message, utils } = require('libp2p-pubsub')
@@ -127,7 +126,7 @@ class FloodSub extends BaseProtocol {
         lp.decode(),
         async function (source) {
           for await (const data of source) {
-            const rpc = Buffer.isBuffer(data) ? data : data.slice()
+            const rpc = data instanceof Uint8Array ? data : data.slice()
 
             onRpcFunc(idB58Str, message.rpc.RPC.decode(rpc))
           }

--- a/test/2-nodes.spec.js
+++ b/test/2-nodes.spec.js
@@ -6,7 +6,8 @@ const chai = require('chai')
 chai.use(require('dirty-chai'))
 chai.use(require('chai-spies'))
 const expect = chai.expect
-const { Buffer } = require('buffer')
+const uint8ArrayFromString = require('uint8arrays/from-string')
+const uint8ArrayToString = require('uint8arrays/to-string')
 const pDefer = require('p-defer')
 const times = require('lodash/times')
 
@@ -115,14 +116,14 @@ describe('basics between 2 nodes', () => {
       const defer = pDefer()
 
       fsA.once('Z', (msg) => {
-        expect(msg.data.toString()).to.equal('hey')
+        expect(uint8ArrayToString(msg.data)).to.equal('hey')
         fsB.removeListener('Z', shouldNotHappen)
         defer.resolve()
       })
 
       fsB.once('Z', shouldNotHappen)
 
-      fsA.publish('Z', Buffer.from('hey'))
+      fsA.publish('Z', uint8ArrayFromString('hey'))
 
       return defer.promise
     })
@@ -132,7 +133,7 @@ describe('basics between 2 nodes', () => {
 
       fsA.once('Z', (msg) => {
         fsA.once('Z', shouldNotHappen)
-        expect(msg.data.toString()).to.equal('banana')
+        expect(uint8ArrayToString(msg.data)).to.equal('banana')
 
         setTimeout(() => {
           fsA.removeListener('Z', shouldNotHappen)
@@ -144,7 +145,7 @@ describe('basics between 2 nodes', () => {
 
       fsB.once('Z', shouldNotHappen)
 
-      fsB.publish('Z', Buffer.from('banana'))
+      fsB.publish('Z', uint8ArrayFromString('banana'))
 
       return defer.promise
     })
@@ -157,9 +158,9 @@ describe('basics between 2 nodes', () => {
       fsA.on('Z', receivedMsg)
 
       function receivedMsg (msg) {
-        expect(msg.data.toString()).to.equal('banana')
+        expect(uint8ArrayToString(msg.data)).to.equal('banana')
         expect(msg.from).to.be.eql(fsB.peerId.toB58String())
-        expect(Buffer.isBuffer(msg.seqno)).to.be.true()
+        expect(msg.seqno).to.be.a('Uint8Array')
         expect(msg.topicIDs).to.be.eql(['Z'])
 
         if (++counter === 10) {
@@ -169,7 +170,7 @@ describe('basics between 2 nodes', () => {
           defer.resolve()
         }
       }
-      times(10, () => fsB.publish('Z', Buffer.from('banana')))
+      times(10, () => fsB.publish('Z', uint8ArrayFromString('banana')))
 
       return defer.promise
     })
@@ -182,9 +183,9 @@ describe('basics between 2 nodes', () => {
       fsA.on('Z', receivedMsg)
 
       function receivedMsg (msg) {
-        expect(msg.data.toString()).to.equal('banana')
+        expect(uint8ArrayToString(msg.data)).to.equal('banana')
         expect(msg.from).to.be.eql(fsB.peerId.toB58String())
-        expect(Buffer.isBuffer(msg.seqno)).to.be.true()
+        expect(msg.seqno).to.be.a('Uint8Array')
         expect(msg.topicIDs).to.be.eql(['Z'])
 
         if (++counter === 10) {
@@ -196,7 +197,7 @@ describe('basics between 2 nodes', () => {
       }
 
       const msgs = []
-      times(10, () => msgs.push(Buffer.from('banana')))
+      times(10, () => msgs.push(uint8ArrayFromString('banana')))
       fsB.publish('Z', msgs)
 
       return defer.promise
@@ -233,8 +234,8 @@ describe('basics between 2 nodes', () => {
         defer.resolve()
       }, 100)
 
-      fsB.publish('Z', Buffer.from('banana'))
-      fsA.publish('Z', Buffer.from('banana'))
+      fsB.publish('Z', uint8ArrayFromString('banana'))
+      fsA.publish('Z', uint8ArrayFromString('banana'))
 
       return defer.promise
     })

--- a/test/emit-self.spec.js
+++ b/test/emit-self.spec.js
@@ -5,7 +5,7 @@ const chai = require('chai')
 chai.use(require('dirty-chai'))
 chai.use(require('chai-spies'))
 const expect = chai.expect
-const { Buffer } = require('buffer')
+const uint8ArrayFromString = require('uint8arrays/from-string')
 const FloodSub = require('../src')
 
 const {
@@ -36,7 +36,7 @@ describe('emit self', () => {
     it('should emit to self on publish', () => {
       const promise = new Promise((resolve) => floodsub.once(topic, resolve))
 
-      floodsub.publish(topic, Buffer.from('hey'))
+      floodsub.publish(topic, uint8ArrayFromString('hey'))
 
       return promise
     })
@@ -59,7 +59,7 @@ describe('emit self', () => {
     it('should emit to self on publish', () => {
       floodsub.once(topic, (m) => shouldNotHappen)
 
-      floodsub.publish(topic, Buffer.from('hey'))
+      floodsub.publish(topic, uint8ArrayFromString('hey'))
 
       // Wait 1 second to guarantee that self is not noticed
       return new Promise((resolve) => setTimeout(() => resolve(), 1000))

--- a/test/multiple-nodes.spec.js
+++ b/test/multiple-nodes.spec.js
@@ -2,10 +2,9 @@
 /* eslint max-nested-callbacks: ["error", 8] */
 'use strict'
 
-const chai = require('chai')
-chai.use(require('dirty-chai'))
-const expect = chai.expect
-const { Buffer } = require('buffer')
+const { expect } = require('aegir/utils/chai')
+const uint8ArrayFromString = require('uint8arrays/from-string')
+const uint8ArrayToString = require('uint8arrays/to-string')
 const pDefer = require('p-defer')
 
 const FloodSub = require('../src')
@@ -172,10 +171,10 @@ describe('multiple nodes (more than 2)', () => {
         psB.on('Z', incMsg)
         psC.on('Z', incMsg)
 
-        psA.publish('Z', Buffer.from('hey'))
+        psA.publish('Z', uint8ArrayFromString('hey'))
 
         function incMsg (msg) {
-          expect(msg.data.toString()).to.equal('hey')
+          expect(uint8ArrayToString(msg.data)).to.equal('hey')
           check()
         }
 
@@ -199,10 +198,10 @@ describe('multiple nodes (more than 2)', () => {
         psB.on('Z', incMsg)
         psC.on('Z', incMsg)
 
-        psA.publish('Z', [Buffer.from('hey'), Buffer.from('hey')])
+        psA.publish('Z', [uint8ArrayFromString('hey'), uint8ArrayFromString('hey')])
 
         function incMsg (msg) {
-          expect(msg.data.toString()).to.equal('hey')
+          expect(uint8ArrayToString(msg.data)).to.equal('hey')
           check()
         }
 
@@ -235,10 +234,10 @@ describe('multiple nodes (more than 2)', () => {
           psB.on('Z', incMsg)
           psC.on('Z', incMsg)
 
-          psB.publish('Z', Buffer.from('hey'))
+          psB.publish('Z', uint8ArrayFromString('hey'))
 
           function incMsg (msg) {
-            expect(msg.data.toString()).to.equal('hey')
+            expect(uint8ArrayToString(msg.data)).to.equal('hey')
             check()
           }
 
@@ -410,10 +409,10 @@ describe('multiple nodes (more than 2)', () => {
         psD.on('Z', incMsg)
         psE.on('Z', incMsg)
 
-        psC.publish('Z', Buffer.from('hey from c'))
+        psC.publish('Z', uint8ArrayFromString('hey from c'))
 
         function incMsg (msg) {
-          expect(msg.data.toString()).to.equal('hey from c')
+          expect(uint8ArrayToString(msg.data)).to.equal('hey from c')
           check()
         }
 

--- a/test/pubsub.spec.js
+++ b/test/pubsub.spec.js
@@ -2,11 +2,9 @@
 /* eslint max-nested-callbacks: ["error", 5] */
 'use strict'
 
-const chai = require('chai')
-chai.use(require('dirty-chai'))
-const expect = chai.expect
+const { expect } = require('aegir/utils/chai')
 const sinon = require('sinon')
-const { Buffer } = require('buffer')
+const uint8ArrayFromString = require('uint8arrays/from-string')
 const Floodsub = require('../src')
 const { createPeerId, mockRegistrar } = require('./utils')
 const { utils } = require('libp2p-pubsub')
@@ -41,7 +39,7 @@ describe('pubsub', () => {
       sinon.spy(utils, 'randomSeqno')
 
       const topic = 'my-topic'
-      const message = Buffer.from('a neat message')
+      const message = uint8ArrayFromString('a neat message')
 
       await floodsub.publish(topic, message)
       expect(floodsub._emitMessages.callCount).to.eql(1)
@@ -61,7 +59,7 @@ describe('pubsub', () => {
       sinon.spy(utils, 'randomSeqno')
 
       const topic = 'my-topic'
-      const message = Buffer.from('a neat message')
+      const message = uint8ArrayFromString('a neat message')
 
       await floodsub.publish(topic, message)
       expect(floodsub._forwardMessages.callCount).to.eql(1)
@@ -92,7 +90,7 @@ describe('pubsub', () => {
         subscriptions: [],
         msgs: [{
           from: peerId.id,
-          data: Buffer.from('an unsigned message'),
+          data: uint8ArrayFromString('an unsigned message'),
           seqno: utils.randomSeqno(),
           topicIDs: [topic]
         }]
@@ -122,7 +120,7 @@ describe('pubsub', () => {
         subscriptions: [],
         msgs: [{
           from: peerId.id,
-          data: Buffer.from('an unsigned message'),
+          data: uint8ArrayFromString('an unsigned message'),
           seqno: utils.randomSeqno(),
           topicIDs: [topic]
         }]


### PR DESCRIPTION
Replaces all use of node Buffers with Uint8Arrays

BREAKING CHANGES:

- The `.data` property of received pubsub messages was a Buffer, now it is a Uint8Array
- All deps of this module use Uint8Arrays