### PR TITLE
chore: remove gh dep from peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "uint8arrays": "^1.1.0"
   },
   "peerDependencies": {
-    "libp2p": "https://github.com/libp2p/js-libp2p#0.29.x"
+    "libp2p": "^0.29.0"
   },
   "contributors": [
     "David Dias <daviddias.p@gmail.com>",


### PR DESCRIPTION
libp2p@0.29.0 was released so we can go back to regular semver for the required version number.