### PR TITLE
chore: update deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,27 +42,27 @@
   },
   "homepage": "https://github.com/libp2p/js-libp2p-floodsub#readme",
   "devDependencies": {
-    "aegir": "^26.0.0",
+    "aegir": "^28.1.0",
     "benchmark": "^2.1.4",
     "chai": "^4.2.0",
-    "ipfs-utils": "^3.0.0",
-    "libp2p": "https://github.com/libp2p/js-libp2p#0.29.x",
-    "libp2p-mplex": "^0.10.0",
-    "libp2p-noise": "^2.0.0",
+    "ipfs-utils": "^4.0.1",
+    "libp2p": "^0.29.3",
+    "libp2p-mplex": "^0.10.1",
+    "libp2p-noise": "^2.0.1",
     "libp2p-websockets": "^0.14.0",
-    "multiaddr": "^8.0.0",
+    "multiaddr": "^8.1.1",
     "p-wait-for": "^3.1.0",
-    "peer-id": "^0.14.00",
-    "sinon": "^9.0.1"
+    "peer-id": "^0.14.2",
+    "sinon": "^9.2.1"
   },
   "dependencies": {
-    "debug": "^4.1.1",
-    "libp2p-interfaces": "^0.5.1",
+    "debug": "^4.2.0",
+    "libp2p-interfaces": "^0.7.2",
     "time-cache": "^0.3.0",
     "uint8arrays": "^1.1.0"
   },
   "peerDependencies": {
-    "libp2p": "^0.29.0"
+    "libp2p": "^0.29.3"
   },
   "contributors": [
     "David Dias <daviddias.p@gmail.com>",

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@
 const debugName = 'libp2p:floodsub'
 
 const TimeCache = require('time-cache')
+const toString = require('uint8arrays/to-string')
 const BaseProtocol = require('libp2p-interfaces/src/pubsub')
 const { utils } = require('libp2p-interfaces/src/pubsub')
 
@@ -15,10 +16,10 @@ const { multicodec } = require('./config')
  */
 class FloodSub extends BaseProtocol {
   /**
-   * @param {Libp2p} libp2p instance of libp2p
+   * @param {Libp2p} libp2p - instance of libp2p
    * @param {Object} [options]
-   * @param {boolean} options.emitSelf if publish should emit to self, if subscribed, defaults to false
-   * @constructor
+   * @param {boolean} options.emitSelf - if publish should emit to self, if subscribed, defaults to false
+   * @class
    */
   constructor (libp2p, options = {}) {
     super({
@@ -40,23 +41,27 @@ class FloodSub extends BaseProtocol {
   /**
    * Process incoming message
    * Extends base implementation to check router cache.
+   *
    * @override
-   * @param {InMessage} message The message to process
+   * @param {InMessage} message - The message to process
    * @returns {Promise<void>}
    */
   async _processRpcMessage (message) {
     // Check if I've seen the message, if yes, ignore
     const seqno = this.getMsgId(message)
-    if (this.seenCache.has(seqno)) {
+    const msgIdStr = toString(seqno, 'base64')
+
+    if (this.seenCache.has(msgIdStr)) {
       return
     }
-    this.seenCache.put(seqno)
+    this.seenCache.put(msgIdStr)
 
     await super._processRpcMessage(message)
   }
 
   /**
    * Publish message created. Forward it to the peers.
+   *
    * @override
    * @param {InMessage} message
    * @returns {void}
@@ -67,6 +72,7 @@ class FloodSub extends BaseProtocol {
 
   /**
    * Forward message to peers.
+   *
    * @param {InMessage} message
    * @returns {void}
    */

--- a/test/floodsub.spec.js
+++ b/test/floodsub.spec.js
@@ -93,12 +93,15 @@ describe('floodsub', () => {
     expect(floodsub1._forwardMessage.callCount).to.eql(1)
     const [messageToEmit] = floodsub1._forwardMessage.getCall(0).args
 
+    const computedSeqno = utils.randomSeqno.getCall(0).returnValue
+    utils.randomSeqno.restore()
+    sinon.stub(utils, 'randomSeqno').returns(computedSeqno)
+
     const expected = utils.normalizeInRpcMessage(
       await floodsub1._buildMessage({
         receivedFrom: peer1.peerId.toB58String(),
         from: peer1.peerId.toB58String(),
         data: message,
-        seqno: utils.randomSeqno.getCall(0).returnValue,
         topicIDs: [topic]
       }))
 

--- a/test/utils/create-peer.js
+++ b/test/utils/create-peer.js
@@ -40,6 +40,11 @@ const defaultConfig = {
 /**
  * Create libp2p node, selectively determining the listen address based on the operating environment
  * If no peerId is given, default to the first peer in the fixtures peer list
+ *
+ * @param {object} options
+ * @param {PeerId} options.peerId
+ * @param {boolean} [options.started=true]
+ * @param {object} [options.config={}]
  */
 async function createPeer ({ peerId, started = true, config = {} } = {}) {
   if (!peerId) {
@@ -63,12 +68,13 @@ async function createPeer ({ peerId, started = true, config = {} } = {}) {
 
 /**
  * Create libp2p nodes from known peer ids, preconfigured to use fixture peer ids
+ *
  * @param {Object} [properties]
  * @param {Object} [properties.config]
- * @param {number} [properties.number] number of peers (default: 1).
- * @param {boolean} [properties.started] nodes should start (default: true)
- * @param {boolean} [properties.seedAddressBook] nodes should have each other in their addressbook
- * @return {Promise<Array<Libp2p>>}
+ * @param {number} [properties.number] - number of peers (default: 1).
+ * @param {boolean} [properties.started] - nodes should start (default: true)
+ * @param {boolean} [properties.seedAddressBook] - nodes should have each other in their addressbook
+ * @returns {Promise<Array<Libp2p>>}
  */
 async function createPeers ({ number = 1, started = true, seedAddressBook = true, config = {} } = {}) {
   const peerIds = await Promise.all(
@@ -96,8 +102,9 @@ async function createPeers ({ number = 1, started = true, seedAddressBook = true
  *
  * If in node, use websocket address
  * If in browser, use relay address
+ *
  * @param {PeerId} peerId
- * @return {multiaddr}
+ * @returns {multiaddr}
  */
 function getListenAddress (peerId) {
   if (isNode) {


### PR DESCRIPTION
This PR updates the dependencies. 

`libp2p-interfaces` pubsub had breaking changes:

- `this.getMsgId` now returns `Uint8Array`
- `_buildMessage` now creates `seqNo` and not receive it

BREAKING CHANGE: signing policy added instead of strictsigning options
