### PR TITLE
chore: update pubsub interface to run subsystem tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        node: [14, 15]
+        node: [14, 16]
       fail-fast: true
     steps:
       - uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "debug": "^4.2.0",
-    "libp2p-interfaces": "^0.10.0",
+    "libp2p-interfaces": "libp2p/js-libp2p-interfaces#chore/complete-pubsub-tests",
     "time-cache": "^0.3.0",
     "uint8arrays": "^2.1.4"
   },

--- a/package.json
+++ b/package.json
@@ -44,28 +44,28 @@
   "homepage": "https://github.com/libp2p/js-libp2p-floodsub#readme",
   "devDependencies": {
     "@types/debug": "^4.1.5",
-    "aegir": "^33.0.0",
+    "aegir": "^33.2.0",
     "benchmark": "^2.1.4",
     "buffer": "^6.0.3",
     "chai": "^4.3.4",
-    "ipfs-utils": "^6.0.6",
+    "ipfs-utils": "^8.1.0",
     "it-pair": "^1.0.0",
-    "libp2p": "^0.31.0",
-    "libp2p-mplex": "^0.10.1",
-    "libp2p-noise": "^2.0.1",
-    "libp2p-websockets": "^0.15.5",
+    "libp2p": "^0.31.6",
+    "libp2p-mplex": "^0.10.3",
+    "libp2p-noise": "^3.0.0",
+    "libp2p-websockets": "^0.15.7",
     "multiaddr": "^9.0.1",
     "os": "^0.1.1",
     "p-wait-for": "^3.1.0",
-    "peer-id": "^0.14.2",
-    "sinon": "^10.0.0",
+    "peer-id": "^0.14.8",
+    "sinon": "^11.1.1",
     "util": "^0.12.3"
   },
   "dependencies": {
     "debug": "^4.2.0",
-    "libp2p-interfaces": "libp2p/js-libp2p-interfaces#chore/complete-pubsub-tests",
+    "libp2p-interfaces": "^0.11.0",
     "time-cache": "^0.3.0",
-    "uint8arrays": "^2.1.4"
+    "uint8arrays": "^2.1.5"
   },
   "contributors": [
     "David Dias <daviddias.p@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "chai": "^4.3.4",
     "ipfs-utils": "^6.0.6",
     "it-pair": "^1.0.0",
-    "libp2p": "^0.30.0",
+    "libp2p": "^0.31.0",
     "libp2p-mplex": "^0.10.1",
     "libp2p-noise": "^2.0.1",
     "libp2p-websockets": "^0.15.5",
@@ -58,7 +58,8 @@
     "os": "^0.1.1",
     "p-wait-for": "^3.1.0",
     "peer-id": "^0.14.2",
-    "sinon": "^10.0.0"
+    "sinon": "^10.0.0",
+    "util": "^0.12.3"
   },
   "dependencies": {
     "debug": "^4.2.0",


### PR DESCRIPTION
This PR updates libp2p interfaces to run all pubsub subsystem tests, moving the ownership of libp2p tests to the modules. Context https://github.com/libp2p/js-libp2p/issues/857

Needs:

- [x] https://github.com/libp2p/js-libp2p-interfaces/pull/81