### PR TITLE
chore: remove peer deps

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,7 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node }}
+      - run: npm install @mapbox/node-pre-gyp -g
       - run: npm install
       - run: npx aegir test -t node --cov --bail
       - uses: codecov/codecov-action@v1

--- a/package.json
+++ b/package.json
@@ -66,9 +66,6 @@
     "time-cache": "^0.3.0",
     "uint8arrays": "^2.1.4"
   },
-  "peerDependencies": {
-    "libp2p": "^0.30.0"
-  },
   "contributors": [
     "David Dias <daviddias.p@gmail.com>",
     "Vasco Santos <vasco.santos@moxy.studio>",


### PR DESCRIPTION
We added peer deps to signal to the user that they should add the modules they depend on as deps of their project.

Starting with npm7 all peer deps get installed automatically which defeats the purpose of our use of peer deps, so let's remove them.