### PR TITLE
feat: async peerstore

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "homepage": "https://github.com/libp2p/js-libp2p-floodsub#readme",
   "devDependencies": {
-    "@chainsafe/libp2p-noise": "^4.1.1",
+    "@chainsafe/libp2p-noise": "^5.0.0",
     "@types/debug": "^4.1.5",
     "aegir": "^36.0.2",
     "benchmark": "^2.1.4",
@@ -51,8 +51,8 @@
     "chai": "^4.3.4",
     "ipfs-utils": "^9.0.2",
     "it-pair": "^1.0.0",
-    "libp2p": "^0.35.0",
-    "libp2p-interfaces-compliance-tests": "^2.0.3",
+    "libp2p": "libp2p/js-libp2p#feat/async-peerstore",
+    "libp2p-interfaces-compliance-tests": "^4.0.0",
     "libp2p-mplex": "^0.10.3",
     "libp2p-websockets": "^0.16.0",
     "multiaddr": "^10.0.0",
@@ -65,7 +65,7 @@
   },
   "dependencies": {
     "debug": "^4.2.0",
-    "libp2p-interfaces": "^2.0.1",
+    "libp2p-interfaces": "^4.0.0",
     "time-cache": "^0.3.0",
     "uint8arrays": "^3.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "ipfs-utils": "^9.0.2",
     "it-pair": "^1.0.0",
     "libp2p": "libp2p/js-libp2p#feat/async-peerstore",
-    "libp2p-interfaces-compliance-tests": "^4.0.0",
+    "libp2p-interfaces-compliance-tests": "^4.0.2",
     "libp2p-mplex": "^0.10.3",
     "libp2p-websockets": "^0.16.0",
     "multiaddr": "^10.0.0",
@@ -65,7 +65,7 @@
   },
   "dependencies": {
     "debug": "^4.2.0",
-    "libp2p-interfaces": "^4.0.0",
+    "libp2p-interfaces": "^4.0.2",
     "time-cache": "^0.3.0",
     "uint8arrays": "^3.0.0"
   },

--- a/test/floodsub.spec.js
+++ b/test/floodsub.spec.js
@@ -39,13 +39,13 @@ describe('floodsub', () => {
     floodsub = new Floodsub(libp2p, defOptions)
   })
 
-  beforeEach(() => {
-    floodsub.start()
+  beforeEach(async () => {
+    await floodsub.start()
   })
 
-  afterEach(() => {
+  afterEach(async () => {
     sinon.restore()
-    floodsub.stop()
+    await floodsub.stop()
   })
 
   it('checks cache when processing incoming message', async function () {


### PR DESCRIPTION
Refactors interfaces and classes used by `libp2p-interfaces` to use the async peer store from https://github.com/libp2p/js-libp2p/pull/1058

BREAKING CHANGE: peerstore methods are now all async