### PR TITLE
docs: add warning not to use this module

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,8 @@
 ## Table of contents <!-- omit in toc -->
 
 - [Install](#install)
+- [Don't use this module](#dont-use-this-module)
 - [Usage](#usage)
-- [API](#api)
-  - [Create a floodsub implementation](#create-a-floodsub-implementation)
-- [Events](#events)
 - [Contribute](#contribute)
 - [License](#license)
 - [Contribution](#contribution)
@@ -25,61 +23,30 @@
 $ npm i @libp2p/floodsub
 ```
 
+## Don't use this module
+
+This module is a naive implementation of pubsub. It broadcasts all messages to all network peers, cannot provide older messages and has no protection against bad actors.
+
+It exists for academic purposes only, you should not use it in production.
+
+Instead please use [gossipsub](https://www.npmjs.com/package/@chainsafe/libp2p-gossipsub) - a more complete implementation which is also compatible with floodsub.
+
 ## Usage
 
 ```JavaScript
 import { FloodSub } from '@libp2p/floodsub'
 
-// registrar is provided by libp2p
-const fsub = new FloodSub(peerId, registrar, options)
+const fsub = new FloodSub()
 
 await fsub.start()
 
-fsub.on('fruit', (data) => {
+fsub.addEventListener('message', (data) => {
   console.log(data)
 })
 fsub.subscribe('fruit')
 
 fsub.publish('fruit', new TextEncoder().encode('banana'))
 ```
-
-## API
-
-### Create a floodsub implementation
-
-```js
-const options = {…}
-const floodsub = new Floodsub(peerId, registrar, options)
-```
-
-Options is an optional object with the following key-value pairs:
-
-- **`emitSelf`**: boolean identifying whether the node should emit to self on publish, in the event of the topic being subscribed (defaults to **false**).
-
-For the remaining API, see <https://github.com/libp2p/js-libp2p-pubsub>
-
-## Events
-
-Floodsub emits two kinds of events:
-
-1. `<topic>` when a message is received for a particular topic
-
-```Javascript
-  fsub.on('fruit', (data) => { ... })
-```
-
-- `data`: a Uint8Array containing the data that was published to the topic
-
-2. `floodsub:subscription-change` when the local peer receives an update to the subscriptions of a remote peer.
-
-```Javascript
-  fsub.on('floodsub:subscription-change', (peerId, topics, changes) => { ... })
-```
-
-- `peerId`: a [PeerId](https://github.com/libp2p/js-peer-id) object
-- `topics`: the topics that the peer is now subscribed to
-- `changes`: an array of `{ topicID: <topic>, subscribe: <boolean> }`
-  eg `[ { topicID: 'fruit', subscribe: true }, { topicID: 'vegetables': false } ]`
 
 ## Contribute
 


### PR DESCRIPTION
Users should favour gossipsub so add a section to the readme informing them they should not use this module.