### PR TITLE
fix!: update multiformats to v11

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,26 +147,26 @@
     "release": "aegir release"
   },
   "dependencies": {
-    "@libp2p/interface-peer-id": "^1.0.2",
+    "@libp2p/interface-peer-id": "^2.0.0",
     "@libp2p/interface-pubsub": "^3.0.0",
     "@libp2p/logger": "^2.0.0",
-    "@libp2p/pubsub": "^5.0.0",
+    "@libp2p/pubsub": "^6.0.0",
     "protons-runtime": "^4.0.1",
     "uint8arraylist": "^2.1.1",
-    "uint8arrays": "^4.0.2"
+    "uint8arrays": "^4.0.3"
   },
   "devDependencies": {
-    "@libp2p/interface-mocks": "^7.0.1",
-    "@libp2p/interface-pubsub-compliance-tests": "^4.0.0",
-    "@libp2p/peer-collections": "^2.0.0",
-    "@libp2p/peer-id": "^1.1.10",
-    "@libp2p/peer-id-factory": "^1.0.9",
+    "@libp2p/interface-mocks": "^9.0.0",
+    "@libp2p/interface-pubsub-compliance-tests": "^5.0.0",
+    "@libp2p/peer-collections": "^3.0.0",
+    "@libp2p/peer-id": "^2.0.0",
+    "@libp2p/peer-id-factory": "^2.0.0",
     "@multiformats/multiaddr": "^11.0.3",
-    "aegir": "^37.2.0",
-    "multiformats": "^10.0.0",
+    "aegir": "^37.9.1",
+    "multiformats": "^11.0.0",
     "p-wait-for": "^5.0.0",
     "protons": "^6.0.0",
-    "sinon": "^14.0.0",
+    "sinon": "^15.0.1",
     "wherearewe": "^2.0.1"
   }
 }


### PR DESCRIPTION
The CID class has breaking changes in v11 so update all deps to the latest version.